### PR TITLE
Removed dangling function argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ module.exports = ({types: t}) => {
 
     const re = t.regExpLiteral(
       pattern,
-      flags,
+      flags
     );
 
     re.extra = {


### PR DESCRIPTION
This was only added to node v8, because this module isn't transformed before publish, it shouldn't use it, otherwise this module won't work with pre v8.