### PR TITLE
Fix README's features option usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,14 @@ which can be specified as an extra object for the plugin:
 
 ```json
 {
-  "plugins": ["transform-modern-regexp", {
-    "features": [
-      "namedCapturingGroups",
-      "xFlag"
-    ]
-  }]
+  "plugins": [
+    ["transform-modern-regexp", {
+      "features": [
+        "namedCapturingGroups",
+        "xFlag"
+      ]
+    }]
+  ]
 }
 ```
 


### PR DESCRIPTION
Without the additional wrapping `[]` Babel understands the object as another plugin, throwing this error:

> Error: [BABEL] .features is not a valid Plugin property